### PR TITLE
Guzzle 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ php:
   - 5.4
   - hhvm
 
-install: composer install
+install: composer require --no-update guzzlehttp/guzzle $GUZZLE_VERSION; composer update
 
 script: vendor/bin/phpunit
+
+env:
+  - GUZZLE_VERSION: 4.2
+  - GUZZLE_VERSION: 5.0
+  - GUZZLE_VERSION: 5.2

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=5.4.0",
         "99designs/http-signatures": "~1.1",
-        "guzzlehttp/guzzle": "~4.2"
+        "guzzlehttp/guzzle": ">=4.2.0 <5.3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1"


### PR DESCRIPTION
 - changed require so that it can be installed with guzzle versions up to `5.2.*`
 - did some black magic with travis to test against different guzzle versions, to avoid breaking BC