### PR TITLE
Allow http-signatures v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": ">=5.5.0",
-        "99designs/http-signatures": ">=3.0.0 <4.0.0",
+        "99designs/http-signatures": ">=3.0.0 <5.0.0",
         "guzzlehttp/guzzle": ">=6.0 <7.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
Allow use of `99designs/http-signatures` v5

See https://github.com/99designs/http-signatures-php/releases for the latest changes